### PR TITLE
Add tests for calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "node test/test.mjs",
     "eject": "react-scripts eject",
     "electron": "electron .",
     "electron:dev": "concurrently \"npm start\" \"wait-on http://localhost:3000 && electron .\"",

--- a/src/shared/calculations.js
+++ b/src/shared/calculations.js
@@ -1,0 +1,103 @@
+/**
+ * Trading Risk Calculator Utilities
+ * Contains pure functions for risk calculations
+ */
+
+export const calculateRiskMetrics = (params) => {
+  const {
+    startingCapital,
+    riskTolerance,
+    dailyMaxLoss,
+    weeklyMaxLoss,
+    sharePrice,
+    numShares,
+    profitTargetPerShare
+  } = params;
+
+  // Basic calculations
+  const shareSize = sharePrice * numShares;
+  const riskPerTrade = (startingCapital * riskTolerance) / 100;
+  const dailyMaxLossAmount = (startingCapital * dailyMaxLoss) / 100;
+  const weeklyMaxLossAmount = (startingCapital * weeklyMaxLoss) / 100;
+  const totalPotentialProfit = numShares * profitTargetPerShare;
+  const totalPotentialLoss = Math.min(shareSize, riskPerTrade);
+  
+  // Risk-to-reward ratio
+  const riskRewardRatio = totalPotentialLoss > 0 ? totalPotentialProfit / totalPotentialLoss : 0;
+  
+  // How many trades can fit in daily/weekly limits
+  const tradesPerDay = totalPotentialLoss > 0 ? Math.floor(dailyMaxLossAmount / totalPotentialLoss) : 0;
+  const tradesPerWeek = totalPotentialLoss > 0 ? Math.floor(weeklyMaxLossAmount / totalPotentialLoss) : 0;
+  
+  // Risk as percentage of capital
+  const riskPercentOfCapital = (totalPotentialLoss / startingCapital) * 100;
+
+  return {
+    shareSize,
+    riskPerTrade,
+    dailyMaxLossAmount,
+    weeklyMaxLossAmount,
+    totalPotentialProfit,
+    totalPotentialLoss,
+    riskRewardRatio,
+    tradesPerDay,
+    tradesPerWeek,
+    riskPercentOfCapital
+  };
+};
+
+export const generateChartData = (params) => {
+  const data = [];
+  
+  // Generate data points for different share quantities
+  for (let i = 0; i <= 200; i += 10) {
+    const shares = i;
+    const shareSize = params.sharePrice * shares;
+    const potentialProfit = shares * params.profitTargetPerShare;
+    const potentialLoss = Math.min(shareSize, (params.startingCapital * params.riskTolerance) / 100);
+    
+    data.push({
+      shares,
+      shareSize,
+      potentialProfit,
+      potentialLoss,
+      riskPercent: (potentialLoss / params.startingCapital) * 100
+    });
+  }
+  
+  return data;
+};
+
+export const validateParams = (params) => {
+  const errors = [];
+  
+  if (params.startingCapital <= 0) {
+    errors.push('Starting capital must be greater than 0');
+  }
+  
+  if (params.riskTolerance <= 0 || params.riskTolerance > 100) {
+    errors.push('Risk tolerance must be between 0 and 100%');
+  }
+  
+  if (params.dailyMaxLoss <= 0 || params.dailyMaxLoss > 100) {
+    errors.push('Daily max loss must be between 0 and 100%');
+  }
+  
+  if (params.weeklyMaxLoss <= 0 || params.weeklyMaxLoss > 100) {
+    errors.push('Weekly max loss must be between 0 and 100%');
+  }
+  
+  if (params.sharePrice <= 0) {
+    errors.push('Share price must be greater than 0');
+  }
+  
+  if (params.numShares <= 0) {
+    errors.push('Number of shares must be greater than 0');
+  }
+  
+  if (params.profitTargetPerShare <= 0) {
+    errors.push('Profit target per share must be greater than 0');
+  }
+  
+  return errors;
+};

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert';
+import { calculateRiskMetrics, generateChartData, validateParams } from '../src/shared/calculations.js';
+
+function testCalculateRiskMetrics() {
+  const params = {
+    startingCapital: 10000,
+    riskTolerance: 2,
+    dailyMaxLoss: 5,
+    weeklyMaxLoss: 10,
+    sharePrice: 50,
+    numShares: 100,
+    profitTargetPerShare: 5
+  };
+  const r = calculateRiskMetrics(params);
+  assert.strictEqual(r.shareSize, 5000);
+  assert.strictEqual(r.riskPerTrade, 200);
+  assert.strictEqual(r.dailyMaxLossAmount, 500);
+  assert.strictEqual(r.weeklyMaxLossAmount, 1000);
+  assert.strictEqual(r.totalPotentialProfit, 500);
+  assert.strictEqual(r.totalPotentialLoss, 200);
+  assert.strictEqual(r.riskRewardRatio, 2.5);
+  assert.strictEqual(r.tradesPerDay, 2);
+  assert.strictEqual(r.tradesPerWeek, 5);
+  assert.strictEqual(r.riskPercentOfCapital, 2);
+}
+
+function testCalculateRiskMetricsZero() {
+  const params = {
+    startingCapital: 10000,
+    riskTolerance: 0,
+    dailyMaxLoss: 5,
+    weeklyMaxLoss: 10,
+    sharePrice: 50,
+    numShares: 100,
+    profitTargetPerShare: 5
+  };
+  const r = calculateRiskMetrics(params);
+  assert.strictEqual(r.totalPotentialLoss, 0);
+  assert.strictEqual(r.riskRewardRatio, 0);
+  assert.strictEqual(r.tradesPerDay, 0);
+}
+
+function testValidateParamsNegative() {
+  const params = {
+    startingCapital: -1,
+    riskTolerance: 150,
+    dailyMaxLoss: -5,
+    weeklyMaxLoss: 0,
+    sharePrice: 0,
+    numShares: -10,
+    profitTargetPerShare: -1
+  };
+  const errors = validateParams(params);
+  assert.ok(errors.includes('Starting capital must be greater than 0'));
+  assert.ok(errors.includes('Risk tolerance must be between 0 and 100%'));
+  assert.ok(errors.includes('Daily max loss must be between 0 and 100%'));
+  assert.ok(errors.includes('Weekly max loss must be between 0 and 100%'));
+  assert.ok(errors.includes('Share price must be greater than 0'));
+  assert.ok(errors.includes('Number of shares must be greater than 0'));
+  assert.ok(errors.includes('Profit target per share must be greater than 0'));
+}
+
+function testGenerateChartData() {
+  const params = {
+    startingCapital: 10000,
+    riskTolerance: 1,
+    sharePrice: 10,
+    profitTargetPerShare: 2
+  };
+  const data = generateChartData({ ...params, numShares: 0 });
+  assert.strictEqual(data[0].shares, 0);
+  assert.strictEqual(data[data.length - 1].shares, 200);
+  assert.ok(data.every(d => d.potentialLoss >= 0));
+}
+
+function run() {
+  testCalculateRiskMetrics();
+  testCalculateRiskMetricsZero();
+  testValidateParamsNegative();
+  testGenerateChartData();
+  console.log('All tests passed.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add shared calculations module
- provide tests for calculations covering negative/zero inputs
- run tests with new npm script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876f44eac188325a04ce7b71d47b154