### PR TITLE
Handle invalid parameters in risk metrics

### DIFF
--- a/src/shared/calculations.js
+++ b/src/shared/calculations.js
@@ -14,6 +14,35 @@ export const calculateRiskMetrics = (params) => {
     profitTargetPerShare
   } = params;
 
+  // Validate inputs before proceeding with calculations
+  const required = [
+    startingCapital,
+    riskTolerance,
+    dailyMaxLoss,
+    weeklyMaxLoss,
+    sharePrice,
+    numShares,
+    profitTargetPerShare
+  ];
+  if (required.some(v => typeof v !== 'number' || Number.isNaN(v))) {
+    throw new Error('Invalid calculation parameters');
+  }
+
+  if (
+    startingCapital <= 0 ||
+    sharePrice <= 0 ||
+    numShares <= 0 ||
+    profitTargetPerShare <= 0 ||
+    riskTolerance < 0 ||
+    riskTolerance > 100 ||
+    dailyMaxLoss < 0 ||
+    dailyMaxLoss > 100 ||
+    weeklyMaxLoss < 0 ||
+    weeklyMaxLoss > 100
+  ) {
+    throw new Error('Invalid calculation parameters');
+  }
+
   // Basic calculations
   const shareSize = sharePrice * numShares;
   const riskPerTrade = (startingCapital * riskTolerance) / 100;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -40,6 +40,32 @@ function testCalculateRiskMetricsZero() {
   assert.strictEqual(r.tradesPerDay, 0);
 }
 
+function testCalculateRiskMetricsInvalid() {
+  const params = {
+    startingCapital: 0,
+    riskTolerance: 2,
+    dailyMaxLoss: 5,
+    weeklyMaxLoss: 10,
+    sharePrice: 50,
+    numShares: 100,
+    profitTargetPerShare: 5
+  };
+  assert.throws(() => calculateRiskMetrics(params), /Invalid calculation parameters/);
+}
+
+function testCalculateRiskMetricsInvalidRange() {
+  const params = {
+    startingCapital: 10000,
+    riskTolerance: 150,
+    dailyMaxLoss: 5,
+    weeklyMaxLoss: 10,
+    sharePrice: 50,
+    numShares: 100,
+    profitTargetPerShare: 5
+  };
+  assert.throws(() => calculateRiskMetrics(params), /Invalid calculation parameters/);
+}
+
 function testValidateParamsNegative() {
   const params = {
     startingCapital: -1,
@@ -76,6 +102,8 @@ function testGenerateChartData() {
 function run() {
   testCalculateRiskMetrics();
   testCalculateRiskMetricsZero();
+  testCalculateRiskMetricsInvalid();
+  testCalculateRiskMetricsInvalidRange();
   testValidateParamsNegative();
   testGenerateChartData();
   console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- validate inputs in `calculateRiskMetrics`
- throw an error on invalid parameter values
- test invalid inputs to `calculateRiskMetrics`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68770999721083258bf24ba9aa707d4b